### PR TITLE
feat: add financial domain models

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,10 +7,40 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-model User {
-  id        Int      @id @default(autoincrement())
-  email     String   @unique
-  name      String?
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+model Usuario {
+  id                  Int                  @id @default(autoincrement())
+  email               String               @unique
+  name                String?
+  ingresos            Float?
+  gastos              Float?
+  ahorro_actual       Float?
+  nivel_actual        Int?
+  historial_economico HistorialEconomico[]
+  createdAt           DateTime             @default(now())
+  updatedAt           DateTime             @updatedAt
+}
+
+model Nivel {
+  id                     Int     @id @default(autoincrement())
+  nombre                 String
+  objetivo_euros         Float
+  contenido_educativo    String?
+  condiciones_desbloqueo String?
+}
+
+model EstrategiaFinanciera {
+  id                     Int     @id @default(autoincrement())
+  nombre                 String
+  tipo                   String
+  rentabilidad_esperada  Float
+  riesgo                 String?
+  condiciones_aplicacion String?
+}
+
+model HistorialEconomico {
+  id         Int      @id @default(autoincrement())
+  usuario    Usuario  @relation(fields: [usuarioId], references: [id])
+  usuarioId  Int
+  fecha      DateTime
+  patrimonio Float
 }


### PR DESCRIPTION
## Summary
- expand Prisma schema with financial models for users, levels, strategies, and economic history

## Testing
- `npx prisma format`
- `npx prisma validate`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_689fb18235848320a71c8c9e8c3b7630