### PR TITLE
feat: add level progress tracking

### DIFF
--- a/app/niveles/page.tsx
+++ b/app/niveles/page.tsx
@@ -1,3 +1,9 @@
+import LevelProgress from '../../components/LevelProgress';
+
 export default function NivelesPage() {
-  return <div>Niveles</div>;
+  return (
+    <div className="p-4">
+      <LevelProgress />
+    </div>
+  );
 }

--- a/components/LevelProgress.tsx
+++ b/components/LevelProgress.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { useLevelStore } from '../store/levelStore';
+
+export default function LevelProgress() {
+  const { wealth, currentLevel, levels, setWealth } = useLevelStore();
+
+  const nextLevel = levels[currentLevel + 1];
+  const currentThreshold = levels[currentLevel].minWealth;
+  const nextThreshold = nextLevel ? nextLevel.minWealth : currentThreshold;
+  const progress = nextLevel
+    ? ((wealth - currentThreshold) / (nextThreshold - currentThreshold)) * 100
+    : 100;
+
+  const unlockedStrategies = levels
+    .slice(0, currentLevel + 1)
+    .flatMap((level) => level.strategies);
+
+  return (
+    <div className="p-4 border rounded flex flex-col gap-4 max-w-md">
+      <div>
+        <label className="flex flex-col">
+          <span>Patrimonio actual</span>
+          <input
+            type="number"
+            value={wealth}
+            onChange={(e) => setWealth(Number(e.target.value))}
+            className="border p-2 rounded"
+          />
+        </label>
+      </div>
+      <h2 className="text-xl font-bold">Nivel actual: {currentLevel + 1}</h2>
+      <div className="w-full bg-gray-200 h-4 rounded">
+        <div
+          className="bg-green-500 h-4 rounded"
+          style={{ width: `${progress}%` }}
+        ></div>
+      </div>
+      <p>{progress.toFixed(2)}% hacia el siguiente nivel</p>
+      <div>
+        <h3 className="font-semibold">Estrategias desbloqueadas</h3>
+        <ul className="list-disc pl-5">
+          {unlockedStrategies.map((s, idx) => (
+            <li key={idx}>{s}</li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/store/levelStore.ts
+++ b/store/levelStore.ts
@@ -1,0 +1,67 @@
+import { create } from 'zustand';
+
+interface EducationalContent {
+  video?: string;
+  text?: string;
+  links?: string[];
+}
+
+interface Level {
+  minWealth: number;
+  strategies: string[];
+  content: EducationalContent;
+}
+
+interface LevelState {
+  wealth: number;
+  currentLevel: number;
+  levels: Level[];
+  setWealth: (wealth: number) => void;
+}
+
+const levelDefinitions: Level[] = [
+  {
+    minWealth: 0,
+    strategies: ['Crea un presupuesto básico', 'Construye un fondo de emergencia'],
+    content: {
+      video: 'https://example.com/intro',
+      text: 'Conceptos básicos de educación financiera.',
+      links: ['https://example.com/presupuesto']
+    }
+  },
+  {
+    minWealth: 10000,
+    strategies: ['Comienza a invertir en instrumentos simples'],
+    content: {
+      video: 'https://example.com/inversiones',
+      text: 'Introducción a la inversión.',
+      links: ['https://example.com/inversiones']
+    }
+  },
+  {
+    minWealth: 50000,
+    strategies: ['Diversifica tu portafolio', 'Optimiza tu carga fiscal'],
+    content: {
+      video: 'https://example.com/estrategias-avanzadas',
+      text: 'Estrategias avanzadas para hacer crecer tu patrimonio.',
+      links: ['https://example.com/portafolio']
+    }
+  }
+];
+
+export const useLevelStore = create<LevelState>((set) => ({
+  wealth: 0,
+  currentLevel: 0,
+  levels: levelDefinitions,
+  setWealth: (wealth) =>
+    set((state) => {
+      let level = state.currentLevel;
+      for (let i = state.levels.length - 1; i >= 0; i--) {
+        if (wealth >= state.levels[i].minWealth) {
+          level = i;
+          break;
+        }
+      }
+      return { wealth, currentLevel: level };
+    })
+}));


### PR DESCRIPTION
## Summary
- track user wealth and financial levels with Zustand
- show level progress, strategies and wealth input
- integrate level progress into levels page

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689fb8e866f48320ba7a6037aaab34fa