### PR TITLE
feat: create dashboard page

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,3 +1,25 @@
+'use client';
+
+import FinancialInputs from '../../components/FinancialInputs';
+import WealthChart from '../../components/WealthChart';
+import LevelProgress from '../../components/LevelProgress';
+import { useStore } from '../../store/useStore';
+
 export default function DashboardPage() {
-  return <div>Dashboard</div>;
+  const patrimonio = useStore((s) => s.patrimonio_simulado);
+  const currentWealth =
+    patrimonio[patrimonio.length - 1]?.value ?? 0;
+
+  return (
+    <main className="flex flex-col space-y-6 p-4 sm:p-6 max-w-4xl mx-auto">
+      <h1 className="text-2xl font-bold">Tu Dashboard Financiero</h1>
+      <p className="text-sm text-gray-600">
+        Patrimonio proyectado en {patrimonio.length} meses: {currentWealth.toFixed(2)}
+      </p>
+      <FinancialInputs />
+      <WealthChart />
+      <LevelProgress />
+    </main>
+  );
 }
+


### PR DESCRIPTION
## Summary
- implement main financial dashboard page with financial inputs, wealth chart, and level progress components
- compute projected wealth using Zustand store and display summary

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689fbb12cd288320915c5a1574cfa5d4