### PR TITLE
Wrap components in collapsible cards

### DIFF
--- a/components/Chart.tsx
+++ b/components/Chart.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { useEffect, useRef } from 'react';
 import * as echarts from 'echarts';
+import CollapsibleCard from './CollapsibleCard';
 
 export default function Chart() {
   const ref = useRef<HTMLDivElement>(null);
@@ -19,5 +20,9 @@ export default function Chart() {
     }
   }, []);
 
-  return <div ref={ref} style={{ width: '100%', height: 400 }} />;
+  return (
+    <CollapsibleCard title="Gráfico de ejemplo">
+      <div ref={ref} style={{ width: '100%', height: 400 }} />
+    </CollapsibleCard>
+  );
 }

--- a/components/CollapsibleCard.tsx
+++ b/components/CollapsibleCard.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { PropsWithChildren, useState } from 'react';
+
+interface CollapsibleCardProps {
+  title: string;
+  initiallyOpen?: boolean;
+}
+
+export default function CollapsibleCard({
+  title,
+  initiallyOpen = true,
+  children,
+}: PropsWithChildren<CollapsibleCardProps>) {
+  const [open, setOpen] = useState(initiallyOpen);
+
+  return (
+    <div className="border rounded shadow" data-testid="collapsible-card">
+      <button
+        type="button"
+        className="w-full flex items-center justify-between p-4 bg-gray-100"
+        onClick={() => setOpen((o) => !o)}
+      >
+        <h2 className="font-semibold text-left">{title}</h2>
+        <span>{open ? '-' : '+'}</span>
+      </button>
+      {open && <div className="p-4">{children}</div>}
+    </div>
+  );
+}
+

--- a/components/FinancialInputs.tsx
+++ b/components/FinancialInputs.tsx
@@ -1,40 +1,43 @@
 'use client';
 
 import { useStore } from '../store/useStore';
+import CollapsibleCard from './CollapsibleCard';
 
 export default function FinancialInputs() {
   const { salary, expenses, savings, setSalary, setExpenses, setSavings } = useStore();
 
   return (
-    <div className="flex flex-col gap-4">
-      <label className="flex flex-col">
-        <span>Salario mensual</span>
-        <input
-          type="number"
-          value={salary}
-          onChange={(e) => setSalary(Number(e.target.value))}
-          className="border p-2 rounded"
-        />
-      </label>
-      <label className="flex flex-col">
-        <span>Gastos mensuales</span>
-        <input
-          type="number"
-          value={expenses}
-          onChange={(e) => setExpenses(Number(e.target.value))}
-          className="border p-2 rounded"
-        />
-      </label>
-      <label className="flex flex-col">
-        <span>Ahorro mensual</span>
-        <input
-          type="number"
-          value={savings}
-          onChange={(e) => setSavings(Number(e.target.value))}
-          className="border p-2 rounded"
-        />
-      </label>
-    </div>
+    <CollapsibleCard title="Datos financieros">
+      <div className="flex flex-col gap-4">
+        <label className="flex flex-col">
+          <span>Salario mensual</span>
+          <input
+            type="number"
+            value={salary}
+            onChange={(e) => setSalary(Number(e.target.value))}
+            className="border p-2 rounded"
+          />
+        </label>
+        <label className="flex flex-col">
+          <span>Gastos mensuales</span>
+          <input
+            type="number"
+            value={expenses}
+            onChange={(e) => setExpenses(Number(e.target.value))}
+            className="border p-2 rounded"
+          />
+        </label>
+        <label className="flex flex-col">
+          <span>Ahorro mensual</span>
+          <input
+            type="number"
+            value={savings}
+            onChange={(e) => setSavings(Number(e.target.value))}
+            className="border p-2 rounded"
+          />
+        </label>
+      </div>
+    </CollapsibleCard>
   );
 }
 

--- a/components/LevelProgress.tsx
+++ b/components/LevelProgress.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useLevelStore } from '../store/levelStore';
+import CollapsibleCard from './CollapsibleCard';
 
 export default function LevelProgress() {
   const { wealth, currentLevel, levels, setWealth } = useLevelStore();
@@ -17,34 +18,36 @@ export default function LevelProgress() {
     .flatMap((level) => level.strategies);
 
   return (
-    <div className="p-4 border rounded flex flex-col gap-4 max-w-md">
-      <div>
-        <label className="flex flex-col">
-          <span>Patrimonio actual</span>
-          <input
-            type="number"
-            value={wealth}
-            onChange={(e) => setWealth(Number(e.target.value))}
-            className="border p-2 rounded"
-          />
-        </label>
+    <CollapsibleCard title="Progreso de nivel">
+      <div className="flex flex-col gap-4 max-w-md">
+        <div>
+          <label className="flex flex-col">
+            <span>Patrimonio actual</span>
+            <input
+              type="number"
+              value={wealth}
+              onChange={(e) => setWealth(Number(e.target.value))}
+              className="border p-2 rounded"
+            />
+          </label>
+        </div>
+        <h2 className="text-xl font-bold">Nivel actual: {currentLevel + 1}</h2>
+        <div className="w-full bg-gray-200 h-4 rounded">
+          <div
+            className="bg-green-500 h-4 rounded"
+            style={{ width: `${progress}%` }}
+          ></div>
+        </div>
+        <p>{progress.toFixed(2)}% hacia el siguiente nivel</p>
+        <div>
+          <h3 className="font-semibold">Estrategias desbloqueadas</h3>
+          <ul className="list-disc pl-5">
+            {unlockedStrategies.map((s, idx) => (
+              <li key={idx}>{s}</li>
+            ))}
+          </ul>
+        </div>
       </div>
-      <h2 className="text-xl font-bold">Nivel actual: {currentLevel + 1}</h2>
-      <div className="w-full bg-gray-200 h-4 rounded">
-        <div
-          className="bg-green-500 h-4 rounded"
-          style={{ width: `${progress}%` }}
-        ></div>
-      </div>
-      <p>{progress.toFixed(2)}% hacia el siguiente nivel</p>
-      <div>
-        <h3 className="font-semibold">Estrategias desbloqueadas</h3>
-        <ul className="list-disc pl-5">
-          {unlockedStrategies.map((s, idx) => (
-            <li key={idx}>{s}</li>
-          ))}
-        </ul>
-      </div>
-    </div>
+    </CollapsibleCard>
   );
 }

--- a/components/WealthChart.tsx
+++ b/components/WealthChart.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef } from 'react';
 import * as echarts from 'echarts';
 import { useStore } from '../store/useStore';
+import CollapsibleCard from './CollapsibleCard';
 
 export default function WealthChart() {
   const ref = useRef<HTMLDivElement>(null);
@@ -35,6 +36,10 @@ export default function WealthChart() {
     };
   }, [data]);
 
-  return <div ref={ref} className="w-full h-80" />;
+  return (
+    <CollapsibleCard title="Gráfico de patrimonio">
+      <div ref={ref} className="w-full h-80" />
+    </CollapsibleCard>
+  );
 }
 


### PR DESCRIPTION
## Summary
- add a generic `CollapsibleCard` component with title and toggle
- render existing UI pieces inside collapsible cards

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689fbe86c304832080f99a8a7e27d1d6