### PR TITLE
Wrap components in collapsible cards and implement themed dashboard

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,25 +1,77 @@
 'use client';
 
+import Link from 'next/link';
 import FinancialInputs from '../../components/FinancialInputs';
 import WealthChart from '../../components/WealthChart';
 import LevelProgress from '../../components/LevelProgress';
 import { useStore } from '../../store/useStore';
+import { useLevelStore } from '../../store/levelStore';
+import { useTheme } from '../../lib/useTheme';
 
 export default function DashboardPage() {
+  const { theme, toggleTheme } = useTheme();
   const patrimonio = useStore((s) => s.patrimonio_simulado);
-  const currentWealth =
-    patrimonio[patrimonio.length - 1]?.value ?? 0;
+  const currentWealth = patrimonio[0]?.value ?? 0;
+  const projection12 = patrimonio[patrimonio.length - 1]?.value ?? 0;
+
+  const { wealth, currentLevel, levels } = useLevelStore();
+  const nextLevel = levels[currentLevel + 1];
+  const currentThreshold = levels[currentLevel].minWealth;
+  const nextThreshold = nextLevel ? nextLevel.minWealth : currentThreshold;
+  const progress = nextLevel
+    ? ((wealth - currentThreshold) / (nextThreshold - currentThreshold)) * 100
+    : 100;
 
   return (
-    <main className="flex flex-col space-y-6 p-4 sm:p-6 max-w-4xl mx-auto">
-      <h1 className="text-2xl font-bold">Tu Dashboard Financiero</h1>
-      <p className="text-sm text-gray-600">
-        Patrimonio proyectado en {patrimonio.length} meses: {currentWealth.toFixed(2)}
-      </p>
+    <main className="min-h-screen bg-gray-100 text-gray-900 dark:bg-zinc-950 dark:text-gray-100 max-w-5xl mx-auto space-y-6 p-6">
+      <div className="relative flex items-start justify-center">
+        <div className="text-center">
+          <h1 className="text-3xl font-bold">Camino a los 100K€</h1>
+          <p className="text-muted-foreground">
+            Tu evolución financiera guiada paso a paso
+          </p>
+        </div>
+        <button
+          onClick={toggleTheme}
+          className="absolute right-0 top-0 rounded border border-gray-200 bg-white p-2 dark:border-zinc-700 dark:bg-zinc-900"
+          aria-label="Cambiar tema"
+        >
+          {theme === 'dark' ? '☀️' : '🌙'}
+        </button>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-3">
+        <div className="p-4 rounded border bg-white text-gray-900 dark:bg-zinc-900 dark:text-gray-100 dark:border-zinc-700">
+          <h3 className="text-sm font-medium">Patrimonio actual</h3>
+          <p className="mt-2 text-2xl font-bold">{currentWealth.toFixed(2)} €</p>
+        </div>
+        <div className="p-4 rounded border bg-white text-gray-900 dark:bg-zinc-900 dark:text-gray-100 dark:border-zinc-700">
+          <h3 className="text-sm font-medium">Proyección a 12 meses</h3>
+          <p className="mt-2 text-2xl font-bold text-green-600">
+            {projection12.toFixed(2)} €
+          </p>
+        </div>
+        <div className="p-4 rounded border bg-white text-gray-900 dark:bg-zinc-900 dark:text-gray-100 dark:border-zinc-700">
+          <h3 className="text-sm font-medium mb-2">Nivel actual: {currentLevel + 1}</h3>
+          <div className="w-full h-3 bg-gray-200 rounded dark:bg-zinc-700">
+            <div
+              className="h-3 bg-green-500 rounded"
+              style={{ width: `${progress}%` }}
+            ></div>
+          </div>
+        </div>
+      </div>
+
       <FinancialInputs />
       <WealthChart />
       <LevelProgress />
+
+      <Link
+        href="/simulador"
+        className="block w-full text-center rounded-md border border-gray-200 bg-gray-100 py-3 text-gray-900 dark:border-zinc-700 dark:bg-zinc-900 dark:text-gray-100"
+      >
+        Ir al simulador de escenarios
+      </Link>
     </main>
   );
 }
-

--- a/components/Chart.tsx
+++ b/components/Chart.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { useEffect, useRef } from 'react';
 import * as echarts from 'echarts';
+import CollapsibleCard from './CollapsibleCard';
 
 export default function Chart() {
   const ref = useRef<HTMLDivElement>(null);
@@ -19,5 +20,9 @@ export default function Chart() {
     }
   }, []);
 
-  return <div ref={ref} style={{ width: '100%', height: 400 }} />;
+  return (
+    <CollapsibleCard title="Gráfico de ejemplo">
+      <div ref={ref} style={{ width: '100%', height: 400 }} />
+    </CollapsibleCard>
+  );
 }

--- a/components/CollapsibleCard.tsx
+++ b/components/CollapsibleCard.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { PropsWithChildren, useState } from 'react';
+
+interface CollapsibleCardProps {
+  title: string;
+  initiallyOpen?: boolean;
+}
+
+export default function CollapsibleCard({
+  title,
+  initiallyOpen = true,
+  children,
+}: PropsWithChildren<CollapsibleCardProps>) {
+  const [open, setOpen] = useState(initiallyOpen);
+
+  return (
+    <div className="border rounded shadow" data-testid="collapsible-card">
+      <button
+        type="button"
+        className="w-full flex items-center justify-between p-4 bg-gray-100"
+        onClick={() => setOpen((o) => !o)}
+      >
+        <h2 className="font-semibold text-left">{title}</h2>
+        <span>{open ? '-' : '+'}</span>
+      </button>
+      {open && <div className="p-4">{children}</div>}
+    </div>
+  );
+}
+

--- a/components/FinancialInputs.tsx
+++ b/components/FinancialInputs.tsx
@@ -1,40 +1,43 @@
 'use client';
 
 import { useStore } from '../store/useStore';
+import CollapsibleCard from './CollapsibleCard';
 
 export default function FinancialInputs() {
   const { salary, expenses, savings, setSalary, setExpenses, setSavings } = useStore();
 
   return (
-    <div className="flex flex-col gap-4">
-      <label className="flex flex-col">
-        <span>Salario mensual</span>
-        <input
-          type="number"
-          value={salary}
-          onChange={(e) => setSalary(Number(e.target.value))}
-          className="border p-2 rounded"
-        />
-      </label>
-      <label className="flex flex-col">
-        <span>Gastos mensuales</span>
-        <input
-          type="number"
-          value={expenses}
-          onChange={(e) => setExpenses(Number(e.target.value))}
-          className="border p-2 rounded"
-        />
-      </label>
-      <label className="flex flex-col">
-        <span>Ahorro mensual</span>
-        <input
-          type="number"
-          value={savings}
-          onChange={(e) => setSavings(Number(e.target.value))}
-          className="border p-2 rounded"
-        />
-      </label>
-    </div>
+    <CollapsibleCard title="Datos financieros">
+      <div className="flex flex-col gap-4">
+        <label className="flex flex-col">
+          <span>Salario mensual</span>
+          <input
+            type="number"
+            value={salary}
+            onChange={(e) => setSalary(Number(e.target.value))}
+            className="border p-2 rounded"
+          />
+        </label>
+        <label className="flex flex-col">
+          <span>Gastos mensuales</span>
+          <input
+            type="number"
+            value={expenses}
+            onChange={(e) => setExpenses(Number(e.target.value))}
+            className="border p-2 rounded"
+          />
+        </label>
+        <label className="flex flex-col">
+          <span>Ahorro mensual</span>
+          <input
+            type="number"
+            value={savings}
+            onChange={(e) => setSavings(Number(e.target.value))}
+            className="border p-2 rounded"
+          />
+        </label>
+      </div>
+    </CollapsibleCard>
   );
 }
 

--- a/components/LevelProgress.tsx
+++ b/components/LevelProgress.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useLevelStore } from '../store/levelStore';
+import CollapsibleCard from './CollapsibleCard';
 
 export default function LevelProgress() {
   const { wealth, currentLevel, levels, setWealth } = useLevelStore();
@@ -17,34 +18,36 @@ export default function LevelProgress() {
     .flatMap((level) => level.strategies);
 
   return (
-    <div className="p-4 border rounded flex flex-col gap-4 max-w-md">
-      <div>
-        <label className="flex flex-col">
-          <span>Patrimonio actual</span>
-          <input
-            type="number"
-            value={wealth}
-            onChange={(e) => setWealth(Number(e.target.value))}
-            className="border p-2 rounded"
-          />
-        </label>
+    <CollapsibleCard title="Progreso de nivel">
+      <div className="flex flex-col gap-4 max-w-md">
+        <div>
+          <label className="flex flex-col">
+            <span>Patrimonio actual</span>
+            <input
+              type="number"
+              value={wealth}
+              onChange={(e) => setWealth(Number(e.target.value))}
+              className="border p-2 rounded"
+            />
+          </label>
+        </div>
+        <h2 className="text-xl font-bold">Nivel actual: {currentLevel + 1}</h2>
+        <div className="w-full bg-gray-200 h-4 rounded">
+          <div
+            className="bg-green-500 h-4 rounded"
+            style={{ width: `${progress}%` }}
+          ></div>
+        </div>
+        <p>{progress.toFixed(2)}% hacia el siguiente nivel</p>
+        <div>
+          <h3 className="font-semibold">Estrategias desbloqueadas</h3>
+          <ul className="list-disc pl-5">
+            {unlockedStrategies.map((s, idx) => (
+              <li key={idx}>{s}</li>
+            ))}
+          </ul>
+        </div>
       </div>
-      <h2 className="text-xl font-bold">Nivel actual: {currentLevel + 1}</h2>
-      <div className="w-full bg-gray-200 h-4 rounded">
-        <div
-          className="bg-green-500 h-4 rounded"
-          style={{ width: `${progress}%` }}
-        ></div>
-      </div>
-      <p>{progress.toFixed(2)}% hacia el siguiente nivel</p>
-      <div>
-        <h3 className="font-semibold">Estrategias desbloqueadas</h3>
-        <ul className="list-disc pl-5">
-          {unlockedStrategies.map((s, idx) => (
-            <li key={idx}>{s}</li>
-          ))}
-        </ul>
-      </div>
-    </div>
+    </CollapsibleCard>
   );
 }

--- a/components/WealthChart.tsx
+++ b/components/WealthChart.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef } from 'react';
 import * as echarts from 'echarts';
 import { useStore } from '../store/useStore';
+import CollapsibleCard from './CollapsibleCard';
 
 export default function WealthChart() {
   const ref = useRef<HTMLDivElement>(null);
@@ -35,6 +36,10 @@ export default function WealthChart() {
     };
   }, [data]);
 
-  return <div ref={ref} className="w-full h-80" />;
+  return (
+    <CollapsibleCard title="Gráfico de patrimonio">
+      <div ref={ref} className="w-full h-80" />
+    </CollapsibleCard>
+  );
 }
 

--- a/lib/useTheme.ts
+++ b/lib/useTheme.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+
+function getInitialTheme(): 'light' | 'dark' {
+  if (typeof window === 'undefined') return 'light';
+  const stored = window.localStorage.getItem('theme') as 'light' | 'dark' | null;
+  if (stored) return stored;
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  return prefersDark ? 'dark' : 'light';
+}
+
+export function useTheme() {
+  const [theme, setTheme] = useState<'light' | 'dark'>(getInitialTheme);
+
+  useEffect(() => {
+    const root = window.document.documentElement;
+    if (theme === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+    window.localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme((t) => (t === 'dark' ? 'light' : 'dark'));
+  };
+
+  return { theme, toggleTheme };
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,7 @@
 import type { Config } from 'tailwindcss';
 
 const config: Config = {
+  darkMode: 'class',
   content: [
     './app/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}'


### PR DESCRIPTION
## Summary
- add a generic `CollapsibleCard` component with title and toggle
- render existing UI pieces inside collapsible cards
- introduce theme toggle hook and new dashboard page with dark/light styling

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689fbe86c304832080f99a8a7e27d1d6